### PR TITLE
Update rggen-verilog-rtl submodule

### DIFF
--- a/tb/common/constants.py
+++ b/tb/common/constants.py
@@ -92,10 +92,6 @@ class cfg_const:
     for param in DMA_CFG_SMALL.items():
         EXTRA_ARGS_SMALL.append("-D"+param[0].upper()+"="+str(param[1]))
 
-    EXTRA_ARGS_32b.append("-DRGGEN_NAIVE_MUX_IMPLEMENTATION")
-    EXTRA_ARGS_64b.append("-DRGGEN_NAIVE_MUX_IMPLEMENTATION")
-    EXTRA_ARGS_SMALL.append("-DRGGEN_NAIVE_MUX_IMPLEMENTATION")
-
     def _get_cfg_args(flavor):
         if flavor == "32":
             return cfg_const.EXTRA_ARGS_32b


### PR DESCRIPTION
I've update rggen-verilog-rtl to replace `recursive function call` with `recursive module instantiation` because some EDA tools do not support `recursive function call`.
upate detail: rggen/rggen-verilog-rtl#7

This PR is to import this change to your project.